### PR TITLE
filled in running sim chapter

### DIFF
--- a/slimChapters/runningSim.Rmd
+++ b/slimChapters/runningSim.Rmd
@@ -41,3 +41,45 @@ late() {
 In the first line of this command (`late()`), we do not specify the generation at which this happens. As a result, it will happen as a late event in *every* generation. 
 
 ## Ending a simulation
+
+We can explicitly end a simulation using the command `sim.simulationFinished()`. 
+
+```{r, engine='bash', eval=FALSE}
+10000 early()
+{
+  sim.simulationFinished();
+} 
+```
+
+This simply ends the simulation. Typically, we want to output something for the user. We'll go into more options throughout the course. For now, know that we can output a sample of our population using the following syntax: 
+
+```{r, engine='bash', eval=FALSE}
+10000 early()
+{
+  p1.outputSample(500);
+} 
+```
+
+where `500` is the number of individuals to output from population `p1`. This outputs a lot of information that is typically sent to a downstream application. 
+
+```{r, engine='bash', eval=FALSE}
+Mutations:
+2 16278 m1 4497 0.0500000007 0.5 p1 1632 27
+```
+
+A simpler output is to use the function `sim.outputFixedMutations()`, which outputs a list of all mutations that have reached fixation (are present in two copies in all individuals).
+
+```{r, engine='bash', eval=FALSE}
+10000 early()
+{
+  sim.outputFixedMutations();
+} 
+```
+
+
+
+
+
+
+
+


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?



#### What was your approach?



#### What GitHub issue does your pull request address?



### Tell potential reviewers what kind of feedback you are soliciting.



### New Content Checklist

- [ ] New content/chapter is in an Rmd file with [this kind of format and headers](https://github.com/jhudsl/OTTR_Template/blob/main/02-chapter_of_course.Rmd).

- [ ] New content/chapter contains learning objectives.

- [ ] [Bookdown successfully re-renders and any new content files have been added to the _bookdown.yml](https://github.com/jhudsl/OTTR_Template/wiki/Publishing-with-Bookdown).

- [ ] [Spell check runs successfully](https://www.ottrproject.org/customize-robots.html#Spell_checking)).

- [ ] Any newly necessary packages that are needed have been added to the [Dockerfile and image](https://www.ottrproject.org/customize-docker.html).

- [ ] Images are in the [correct format for rendering](https://www.ottrproject.org/writing_content.html#set-up-images).

- [ ] Every new image has [alt text and is in a Google Slide](https://www.ottrproject.org/writing_content.html#Accessibility).

- [ ] Each slide is described in the notes of the slide so learners relying on a screen reader can access the content. See https://lastcallmedia.com/blog/accessible-comics for more guidance on this.

- [ ] The color palette choices of the slide are contrasted in a way that is friendly to those with color vision deficiencies.
You can check this using [Color Oracle](https://colororacle.org/).
